### PR TITLE
feat: scaffold team sync preview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ github-compliance-cli run --config compliance.yml --token ghp_xxx --dry-run
 github-compliance-cli run -c config.yml -t ghp_xxx --repos "repo1,repo2"
 
 # Run specific checks only
-github-compliance-cli run -c config.yml -t ghp_xxx --checks "merge-methods,security-scanning"
+github-compliance-cli run -c config.yml -t ghp_xxx --checks "repo-merge-strategy,repo-security-controls"
 
 # Generate JSON report
 github-compliance-cli run -c config.yml -t ghp_xxx --format json --output report.json
@@ -132,11 +132,12 @@ npm run lint:types
 - **Base Class**: `src/checks/base.ts` - Abstract `BaseCheck` with common functionality
 - **Check Interface**: `ComplianceCheck` interface defines `shouldRun()`, `check()`, `fix()` methods
 - **Available Checks**:
-  - `merge-methods` - Repository merge button settings
-  - `branch-protection` - Protected branch rules
-  - `team-permissions` - Team access and individual collaborator removal
-  - `security-scanning` - Dependabot, secret scanning, code scanning
-  - `archived-repos` - Admin team access validation for archived repositories
+  - `org-team-sync` - Organization team synchronization
+  - `repo-merge-strategy` - Repository merge button settings
+  - `repo-branch-protection` - Protected branch rules
+  - `repo-access-teams` - Team access and individual collaborator removal
+  - `repo-security-controls` - Dependabot, secret scanning, code scanning
+  - `repo-archival-policy` - Admin team access validation for archived repositories
 - **Registry**: `src/runner/check-registry.ts` maps check names to implementations
 
 ### GitHub Client Architecture

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ github-compliance-cli run -c compliance.yml -t ghp_xxx --repos "frontend,backend
 
 # Run specific checks with JSON output
 github-compliance-cli run -c compliance.yml -t ghp_xxx \
-  --checks "merge-methods,security-scanning" \
+  --checks "repo-merge-strategy,repo-security-controls" \
   --format json --output compliance-report.json
 
 # Apply fixes (no dry-run) and include archived repositories
@@ -99,11 +99,14 @@ The CLI can perform the following compliance checks:
 
 | Check ID | Description |
 |----------|-------------|
-| `merge-methods` | Validates allowed merge strategies (merge commit, squash, rebase) |
-| `branch-protection` | Ensures branch protection rules are properly configured |
-| `team-permissions` | Manages team access levels and removes individual collaborators |
-| `security-scanning` | Verifies security features (secret scanning, Dependabot, code scanning) |
-| `archived-repos` | Controls access to archived repositories |
+| `org-team-sync` | Synchronizes organization teams against the desired configuration |
+| `repo-merge-strategy` | Validates allowed merge strategies (merge commit, squash, rebase) |
+| `repo-branch-protection` | Ensures branch protection rules are properly configured |
+| `repo-access-teams` | Manages repository team access and individual collaborators |
+| `repo-security-controls` | Verifies security features (secret scanning, Dependabot, code scanning) |
+| `repo-archival-policy` | Controls access to archived repositories |
+
+Legacy identifiers (merge-methods, team-permissions, branch-protection, security-scanning, archived-repos, team-sync) are still accepted and automatically mapped to the new names.
 
 Each check can be configured in the `defaults` section of your configuration file and selectively applied using the `--checks` flag.
 

--- a/compliance-config.example.yml
+++ b/compliance-config.example.yml
@@ -79,8 +79,9 @@ rules:
 # Compliance checks to run (optional, defaults to all)
 checks:
   enabled:
-    - "merge-methods"
-    - "team-permissions"
-    - "branch-protection"
-    - "security-scanning"
-    - "archived-repos"
+    - "org-team-sync"
+    - "repo-merge-strategy"
+    - "repo-access-teams"
+    - "repo-branch-protection"
+    - "repo-security-controls"
+    - "repo-archival-policy"

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -343,24 +343,30 @@ Specifies which compliance checks to run.
 | `enabled` | `string[]` | List of checks to enable |
 
 **Available Checks**:
-- `merge-methods`: Validates merge button settings
-- `team-permissions`: Validates team access and removes individual collaborators
-- `branch-protection`: Ensures branch protection rules are configured
-- `security-scanning`: Validates security features are enabled
-- `archived-repos`: Validates archived repository settings
+- `org-team-sync`: Synchronizes organization teams with the desired state
+- `repo-merge-strategy`: Validates merge button settings
+- `repo-access-teams`: Validates team access and removes individual collaborators
+- `repo-branch-protection`: Ensures branch protection rules are configured
+- `repo-security-controls`: Validates security features are enabled
+- `repo-archival-policy`: Validates archived repository settings
 
 **Example**:
 ```yaml
 checks:
   enabled:
-    - merge-methods
-    - team-permissions
-    - branch-protection
-    - security-scanning
-    - archived-repos
+    - org-team-sync
+    - repo-merge-strategy
+    - repo-access-teams
+    - repo-branch-protection
+    - repo-security-controls
+    - repo-archival-policy
 ```
 
 If not specified, all checks are enabled by default.
+
+> Legacy identifiers (merge-methods, team-permissions, branch-protection,
+> security-scanning, archived-repos, team-sync) are still accepted and
+> automatically mapped to the new names.
 
 ## Complete Configuration Example
 
@@ -471,11 +477,12 @@ rules:
 # Enabled compliance checks
 checks:
   enabled:
-    - merge-methods
-    - team-permissions
-    - branch-protection
-    - security-scanning
-    - archived-repos
+    - org-team-sync
+    - repo-merge-strategy
+    - repo-access-teams
+    - repo-branch-protection
+    - repo-security-controls
+    - repo-archival-policy
 ```
 
 ## Best Practices

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -11,7 +11,7 @@ jest.mock('../config/validator', () => ({
       organization: 'test-org',
       defaults: {
         checks: {
-          'merge-methods': {
+          'repo-merge-strategy': {
             allow_merge_commit: false,
             allow_squash_merge: true,
             allow_rebase_merge: false,
@@ -63,7 +63,7 @@ describe('CLI Commands', () => {
 organization: test-org
 defaults:
   checks:
-    merge-methods:
+    repo-merge-strategy:
       allow_merge_commit: false
       allow_squash_merge: true
       allow_rebase_merge: false
@@ -169,7 +169,7 @@ defaults:
           config: testConfigPath,
           token: 'test-token',
           repos: 'repo1,repo2',
-          checks: 'merge-methods,security-scanning',
+          checks: 'repo-merge-strategy,repo-security-controls',
         })
       ).rejects.toThrow('process.exit');
 
@@ -177,7 +177,7 @@ defaults:
         .calls[0];
       expect(runnerConstructor[2]).toMatchObject({
         repos: ['repo1', 'repo2'],
-        checks: ['merge-methods', 'security-scanning'],
+        checks: ['repo-merge-strategy', 'repo-security-controls'],
       });
     });
 

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -5,6 +5,9 @@ export type CacheNamespace =
   | 'branchProtection'
   | 'collaborators'
   | 'teamPermissions'
+  | 'teams'
+  | 'teamMembers'
+  | 'orgMembers'
   | 'securitySettings'
   | 'vulnerabilityAlerts'
   | 'currentUser';
@@ -17,6 +20,9 @@ export interface CacheTtlConfig {
   branchProtection?: number;
   collaborators?: number;
   teamPermissions?: number;
+  teams?: number;
+  teamMembers?: number;
+  orgMembers?: number;
   securitySettings?: number;
   vulnerabilityAlerts?: number;
   currentUser?: number;

--- a/src/checks/__tests__/archived-repos.test.ts
+++ b/src/checks/__tests__/archived-repos.test.ts
@@ -819,7 +819,7 @@ describe('ArchivedReposCheck', () => {
 
   describe('property getters', () => {
     it('should have correct name', () => {
-      expect(check.name).toBe('archived-repos');
+      expect(check.name).toBe('repo-archival-policy');
     });
 
     it('should have correct description', () => {

--- a/src/checks/__tests__/branch-protection.test.ts
+++ b/src/checks/__tests__/branch-protection.test.ts
@@ -881,7 +881,7 @@ describe('BranchProtectionCheck', () => {
 
   describe('property getters', () => {
     it('should have correct name', () => {
-      expect(check.name).toBe('branch-protection');
+      expect(check.name).toBe('repo-branch-protection');
     });
 
     it('should have correct description', () => {

--- a/src/checks/__tests__/merge-methods.test.ts
+++ b/src/checks/__tests__/merge-methods.test.ts
@@ -570,7 +570,7 @@ describe('MergeMethodsCheck', () => {
 
   describe('property getters', () => {
     it('should have correct name', () => {
-      expect(check.name).toBe('merge-methods');
+      expect(check.name).toBe('repo-merge-strategy');
     });
 
     it('should have correct description', () => {

--- a/src/checks/__tests__/security-scanning.test.ts
+++ b/src/checks/__tests__/security-scanning.test.ts
@@ -887,7 +887,7 @@ describe('SecurityScanningCheck', () => {
 
   describe('property getters', () => {
     it('should have correct name', () => {
-      expect(check.name).toBe('security-scanning');
+      expect(check.name).toBe('repo-security-controls');
     });
 
     it('should have correct description', () => {

--- a/src/checks/__tests__/team-permissions.test.ts
+++ b/src/checks/__tests__/team-permissions.test.ts
@@ -1020,7 +1020,7 @@ describe('TeamPermissionsCheck', () => {
 
   describe('property getters', () => {
     it('should have correct name', () => {
-      expect(check.name).toBe('team-permissions');
+      expect(check.name).toBe('repo-access-teams');
     });
 
     it('should have correct description', () => {

--- a/src/checks/__tests__/team-sync.test.ts
+++ b/src/checks/__tests__/team-sync.test.ts
@@ -103,7 +103,7 @@ describe('TeamSyncCheck', () => {
 
     const result = await check.check(createContext(config));
 
-    expect(result.compliant).toBe(true);
+    expect(result.compliant).toBe(false);
     expect(result.message).toContain('Preview: processed 1 team(s)');
     expect(syncSpy).toHaveBeenCalledTimes(1);
     syncSpy.mockRestore();

--- a/src/checks/__tests__/team-sync.test.ts
+++ b/src/checks/__tests__/team-sync.test.ts
@@ -1,0 +1,131 @@
+import type { ComplianceConfig } from '../../config/types';
+import type { GitHubClient, Repository } from '../../github/types';
+import { type Logger, resetLogger, setLogger } from '../../logging';
+import { TeamManager } from '../../teams';
+import type { CheckContext } from '../base';
+import { TeamSyncCheck } from '../team-sync';
+
+const mockLogger: jest.Mocked<Logger> = {
+  info: jest.fn(),
+  success: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  startGroup: jest.fn(),
+  endGroup: jest.fn(),
+};
+
+const mockRepository: Repository = {
+  id: 1,
+  name: 'demo',
+  full_name: 'octo/demo',
+  private: false,
+  archived: false,
+  disabled: false,
+  fork: false,
+  default_branch: 'main',
+  updated_at: '2024-01-01T00:00:00Z',
+  pushed_at: '2024-01-01T00:00:00Z',
+  stargazers_count: 0,
+  forks_count: 0,
+  open_issues_count: 0,
+  size: 1,
+  language: 'TypeScript',
+};
+
+describe('TeamSyncCheck', () => {
+  const client = {} as GitHubClient;
+  let check: TeamSyncCheck;
+
+  beforeEach(() => {
+    check = new TeamSyncCheck();
+    jest.clearAllMocks();
+    setLogger(mockLogger);
+  });
+
+  afterEach(() => {
+    resetLogger();
+  });
+
+  function createContext(config: ComplianceConfig, dryRun = false): CheckContext {
+    return {
+      client,
+      config,
+      dryRun,
+      repository: mockRepository,
+    };
+  }
+
+  it('should not run when no team configuration is defined', () => {
+    const config: ComplianceConfig = {
+      version: 1,
+      defaults: {},
+    };
+
+    expect(check.shouldRun(createContext(config))).toBe(false);
+  });
+
+  it('should run when team configuration is provided', () => {
+    const config: ComplianceConfig = {
+      version: 1,
+      defaults: {},
+      teams: {
+        definitions: [{ name: 'platform' }],
+      },
+    };
+
+    expect(check.shouldRun(createContext(config))).toBe(true);
+  });
+
+  it('should return a compliant result summarizing preview mode', async () => {
+    const config: ComplianceConfig = {
+      version: 1,
+      defaults: {},
+      teams: {
+        definitions: [{ name: 'platform', members: [{ username: 'octocat' }] }],
+      },
+    };
+
+    const result = await check.check(createContext(config));
+
+    expect(result.compliant).toBe(true);
+    expect(result.message).toContain('not yet implemented');
+    expect(result.details?.stats).toEqual({
+      processed: 1,
+      created: 0,
+      updated: 0,
+      removed: 0,
+      skipped: 1,
+    });
+  });
+
+  it('should call team manager sync during fix', async () => {
+    const config: ComplianceConfig = {
+      version: 1,
+      defaults: {},
+      teams: {
+        definitions: [{ name: 'platform' }],
+      },
+    };
+
+    const syncSpy = jest.spyOn(TeamManager.prototype, 'sync').mockResolvedValue({
+      hasChanges: false,
+      hasErrors: false,
+      findings: [],
+      summary: 'noop',
+      stats: {
+        processed: 0,
+        created: 0,
+        updated: 0,
+        removed: 0,
+        skipped: 0,
+      },
+    });
+
+    await check.fix(createContext(config, false));
+
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+
+    syncSpy.mockRestore();
+  });
+});

--- a/src/checks/archived-repos.ts
+++ b/src/checks/archived-repos.ts
@@ -3,7 +3,7 @@ import { BaseCheck, type CheckContext, type CheckResult } from './base';
 import type { AppliedAction, CheckAction, CheckDetails } from './types';
 
 export class ArchivedReposCheck extends BaseCheck {
-  readonly name = 'archived-repos';
+  readonly name = 'repo-archival-policy';
   readonly description = 'Verify repository archival status and cleanup';
 
   shouldRun(context: CheckContext): boolean {

--- a/src/checks/branch-protection.ts
+++ b/src/checks/branch-protection.ts
@@ -3,7 +3,7 @@ import { BaseCheck, type CheckContext, type CheckResult } from './base';
 import type { AppliedAction, CheckDetails } from './types';
 
 export class BranchProtectionCheck extends BaseCheck {
-  readonly name = 'branch-protection';
+  readonly name = 'repo-branch-protection';
   readonly description = 'Verify repository branch protection rules';
 
   shouldRun(context: CheckContext): boolean {

--- a/src/checks/index.ts
+++ b/src/checks/index.ts
@@ -4,4 +4,5 @@ export * from './branch-protection';
 export * from './merge-methods';
 export * from './security-scanning';
 export * from './team-permissions';
+export * from './team-sync';
 export * from './types';

--- a/src/checks/merge-methods.ts
+++ b/src/checks/merge-methods.ts
@@ -3,7 +3,7 @@ import { BaseCheck, type CheckContext, type CheckResult } from './base';
 import type { CheckDetails, RepositoryUpdateSettings, RepositoryWithMergeMethods } from './types';
 
 export class MergeMethodsCheck extends BaseCheck {
-  readonly name = 'merge-methods';
+  readonly name = 'repo-merge-strategy';
   readonly description = 'Verify repository merge methods configuration';
 
   shouldRun(context: CheckContext): boolean {

--- a/src/checks/security-scanning.ts
+++ b/src/checks/security-scanning.ts
@@ -10,7 +10,7 @@ import type {
 } from './types';
 
 export class SecurityScanningCheck extends BaseCheck {
-  readonly name = 'security-scanning';
+  readonly name = 'repo-security-controls';
   readonly description = 'Verify repository security scanning settings';
 
   shouldRun(context: CheckContext): boolean {

--- a/src/checks/team-permissions.ts
+++ b/src/checks/team-permissions.ts
@@ -3,7 +3,7 @@ import { BaseCheck, type CheckContext, type CheckResult } from './base';
 import type { AppliedAction, CheckDetails, CollaboratorPermissions } from './types';
 
 export class TeamPermissionsCheck extends BaseCheck {
-  readonly name = 'team-permissions';
+  readonly name = 'repo-access-teams';
   readonly description = 'Verify repository team permissions and collaborator access';
 
   shouldRun(context: CheckContext): boolean {

--- a/src/checks/team-sync.ts
+++ b/src/checks/team-sync.ts
@@ -18,7 +18,7 @@ function createLoggerAdapter(): Logger {
 }
 
 export class TeamSyncCheck extends BaseCheck {
-  readonly name = 'team-sync';
+  readonly name = 'org-team-sync';
   readonly description = 'Preview of GitHub team synchronization based on configuration.';
 
   shouldRun(context: CheckContext): boolean {

--- a/src/checks/team-sync.ts
+++ b/src/checks/team-sync.ts
@@ -50,6 +50,13 @@ export class TeamSyncCheck extends BaseCheck {
       return this.createErrorResult('Team synchronization encountered errors', result.summary);
     }
 
+    if (result.hasChanges) {
+      return this.createNonCompliantResult(result.summary, {
+        findings: result.findings,
+        stats: result.stats,
+      });
+    }
+
     return this.createCompliantResult(result.summary, {
       findings: result.findings,
       stats: result.stats,
@@ -85,7 +92,7 @@ export class TeamSyncCheck extends BaseCheck {
       return this.createErrorResult('Team synchronization encountered errors', result.summary);
     }
 
-    return this.createCompliantResult(result.summary, {
+    return this.createFixedResult(result.summary, {
       findings: result.findings,
       stats: result.stats,
     });

--- a/src/checks/team-sync.ts
+++ b/src/checks/team-sync.ts
@@ -30,13 +30,18 @@ export class TeamSyncCheck extends BaseCheck {
       return this.createCompliantResult('No team configuration defined for this run.');
     }
 
-    const options: TeamSyncOptions = { dryRun: true };
+    const baseOptions: TeamSyncOptions = {
+      dryRun: true,
+    };
+    if (context.config.organization) {
+      baseOptions.owner = context.config.organization;
+    }
     const unmanagedTeams = context.config.teams.unmanaged_teams;
     const manager = new TeamManager(
       context.client,
       context.config.teams,
       createLoggerAdapter(),
-      unmanagedTeams !== undefined ? { ...options, unmanagedTeams } : options
+      unmanagedTeams !== undefined ? { ...baseOptions, unmanagedTeams } : baseOptions
     );
 
     const result = await manager.sync();
@@ -60,13 +65,18 @@ export class TeamSyncCheck extends BaseCheck {
       return this.check(context);
     }
 
-    const options: TeamSyncOptions = { dryRun: false };
+    const baseOptions: TeamSyncOptions = {
+      dryRun: false,
+    };
+    if (context.config.organization) {
+      baseOptions.owner = context.config.organization;
+    }
     const unmanagedTeams = context.config.teams.unmanaged_teams;
     const manager = new TeamManager(
       context.client,
       context.config.teams,
       createLoggerAdapter(),
-      unmanagedTeams !== undefined ? { ...options, unmanagedTeams } : options
+      unmanagedTeams !== undefined ? { ...baseOptions, unmanagedTeams } : baseOptions
     );
 
     const result = await manager.sync();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -262,11 +262,11 @@ async function validateCommand(options: ValidateOptions): Promise<void> {
         const defaults = (config as ComplianceConfig).defaults;
         if (defaults) {
           const checkTypes: string[] = [];
-          if (defaults.merge_methods) checkTypes.push('merge-methods');
-          if (defaults.branch_protection) checkTypes.push('branch-protection');
-          if (defaults.security) checkTypes.push('security');
-          if (defaults.permissions) checkTypes.push('permissions');
-          if (defaults.archived_repos) checkTypes.push('archived-repos');
+          if (defaults.merge_methods) checkTypes.push('repo-merge-strategy');
+          if (defaults.branch_protection) checkTypes.push('repo-branch-protection');
+          if (defaults.security) checkTypes.push('repo-security-controls');
+          if (defaults.permissions) checkTypes.push('repo-access-teams');
+          if (defaults.archived_repos) checkTypes.push('repo-archival-policy');
 
           if (checkTypes.length > 0) {
             logger.info(`  Configured checks: ${checkTypes.join(', ')}`);

--- a/src/config/__tests__/teams-schema.test.ts
+++ b/src/config/__tests__/teams-schema.test.ts
@@ -1,0 +1,170 @@
+import { ComplianceConfigSchema } from '../schema';
+
+describe('ComplianceConfigSchema teams', () => {
+  const baseConfig = {
+    version: 1 as const,
+    defaults: {},
+  };
+
+  it('accepts teams definitions and dynamic rules', () => {
+    const config = {
+      ...baseConfig,
+      teams: {
+        definitions: [
+          {
+            name: 'platform',
+            description: 'Handles platform tooling',
+            members: [{ username: 'octocat', role: 'maintainer' }, { username: 'hubot' }],
+            privacy: 'closed' as const,
+            notification_setting: 'notifications_enabled' as const,
+          },
+        ],
+        dynamic_rules: [
+          {
+            name: 'all-members',
+            type: 'all_org_members' as const,
+          },
+          {
+            name: 'qa-team',
+            type: 'by_filter' as const,
+            filter: {
+              usernames: ['quality-bot'],
+              with_repo_access: ['octo/repo'],
+            },
+          },
+          {
+            name: 'ops-core',
+            type: 'composite' as const,
+            compose: {
+              union: ['platform', 'qa-team'],
+              difference: {
+                from: 'platform',
+                subtract: ['contractors'],
+              },
+            },
+          },
+        ],
+        unmanaged_teams: 'warn' as const,
+        dry_run: true,
+      },
+    };
+
+    expect(() => ComplianceConfigSchema.parse(config)).not.toThrow();
+  });
+
+  it('rejects by_filter rules without filter block', () => {
+    const config = {
+      ...baseConfig,
+      teams: {
+        dynamic_rules: [
+          {
+            name: 'invalid-filter',
+            type: 'by_filter' as const,
+          },
+        ],
+      },
+    };
+
+    expect(() => ComplianceConfigSchema.parse(config)).toThrow(
+      'by_filter rules require a filter block'
+    );
+  });
+
+  it('rejects composite rules without compose block', () => {
+    const config = {
+      ...baseConfig,
+      teams: {
+        dynamic_rules: [
+          {
+            name: 'invalid-composite',
+            type: 'composite' as const,
+          },
+        ],
+      },
+    };
+
+    expect(() => ComplianceConfigSchema.parse(config)).toThrow(
+      'composite rules require a compose block'
+    );
+  });
+
+  it('rejects filters without any criteria', () => {
+    const config = {
+      ...baseConfig,
+      teams: {
+        dynamic_rules: [
+          {
+            name: 'empty-filter',
+            type: 'by_filter' as const,
+            filter: {},
+          },
+        ],
+      },
+    };
+
+    expect(() => ComplianceConfigSchema.parse(config)).toThrow(
+      'Team member filter must specify at least one criterion'
+    );
+  });
+
+  it('rejects composite operations without any operation defined', () => {
+    const config = {
+      ...baseConfig,
+      teams: {
+        dynamic_rules: [
+          {
+            name: 'empty-composition',
+            type: 'composite' as const,
+            compose: {},
+          },
+        ],
+      },
+    };
+
+    expect(() => ComplianceConfigSchema.parse(config)).toThrow(
+      'Team composition must include at least one operation'
+    );
+  });
+
+  it('rejects filter on non-filter rule types', () => {
+    const config = {
+      ...baseConfig,
+      teams: {
+        dynamic_rules: [
+          {
+            name: 'unexpected-filter',
+            type: 'all_org_members' as const,
+            filter: {
+              usernames: ['octocat'],
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => ComplianceConfigSchema.parse(config)).toThrow(
+      'Only by_filter rules may specify filter'
+    );
+  });
+
+  it('rejects compose on non-composite rule types', () => {
+    const config = {
+      ...baseConfig,
+      teams: {
+        dynamic_rules: [
+          {
+            name: 'unexpected-compose',
+            type: 'all_org_members' as const,
+            compose: {
+              union: ['platform'],
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => ComplianceConfigSchema.parse(config)).toThrow(
+      'Only composite rules may specify compose'
+    );
+  });
+});

--- a/src/config/__tests__/validator.test.ts
+++ b/src/config/__tests__/validator.test.ts
@@ -69,7 +69,7 @@ rules:
         secret_scanning_push_protection: "enabled"
 
 checks:
-  enabled: ["merge-methods", "team-permissions", "branch-protection"]
+  enabled: ["repo-merge-strategy", "repo-access-teams", "repo-branch-protection"]
 
 cache:
   enabled: true
@@ -115,8 +115,28 @@ describe('Config validation', () => {
       expect(config.defaults.merge_methods?.allow_squash_merge).toBe(true);
       expect(config.defaults.branch_protection?.patterns).toEqual(['main', 'release/v*']);
       expect(config.rules).toHaveLength(2);
-      expect(config.checks?.enabled).toContain('merge-methods');
+      expect(config.checks?.enabled).toContain('repo-merge-strategy');
       expect(config.cache?.enabled).toBe(true);
+    });
+
+    it('maps legacy check names to new identifiers', async () => {
+      const legacyConfig = `
+version: 1
+defaults: {}
+checks:
+  enabled:
+    - merge-methods
+    - team-permissions
+    - team-sync
+`;
+
+      const config = await validateFromString(legacyConfig);
+
+      expect(config.checks?.enabled).toEqual([
+        'repo-merge-strategy',
+        'repo-access-teams',
+        'org-team-sync',
+      ]);
     });
 
     it('should reject invalid YAML syntax', async () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -275,17 +275,44 @@ const RuleSchema = z.object({
     .partial(),
 });
 
+const NEW_CHECK_NAMES = [
+  'org-team-sync',
+  'repo-merge-strategy',
+  'repo-access-teams',
+  'repo-branch-protection',
+  'repo-security-controls',
+  'repo-archival-policy',
+] as const;
+
+const LEGACY_CHECK_NAMES = [
+  'team-sync',
+  'merge-methods',
+  'team-permissions',
+  'branch-protection',
+  'security-scanning',
+  'archived-repos',
+] as const;
+
+const LEGACY_CHECK_NAME_ALIASES: Record<
+  (typeof LEGACY_CHECK_NAMES)[number],
+  (typeof NEW_CHECK_NAMES)[number]
+> = {
+  'team-sync': 'org-team-sync',
+  'merge-methods': 'repo-merge-strategy',
+  'team-permissions': 'repo-access-teams',
+  'branch-protection': 'repo-branch-protection',
+  'security-scanning': 'repo-security-controls',
+  'archived-repos': 'repo-archival-policy',
+};
+
+const CheckNameSchema = z
+  .union([z.enum(NEW_CHECK_NAMES), z.enum(LEGACY_CHECK_NAMES)])
+  .transform(
+    (value) => LEGACY_CHECK_NAME_ALIASES[value as (typeof LEGACY_CHECK_NAMES)[number]] ?? value
+  );
+
 const ChecksSchema = z.object({
-  enabled: z.array(
-    z.enum([
-      'merge-methods',
-      'team-permissions',
-      'branch-protection',
-      'security-scanning',
-      'archived-repos',
-      'team-sync',
-    ])
-  ),
+  enabled: z.array(CheckNameSchema),
 });
 
 export const ComplianceConfigSchema = z.object({

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -75,6 +75,60 @@ export interface Permissions {
   users?: ConfigUserPermission[];
 }
 
+export type TeamPrivacy = 'secret' | 'closed';
+
+export type TeamNotificationSetting = 'notifications_enabled' | 'notifications_disabled';
+
+export interface TeamMember {
+  username: string;
+  role?: 'member' | 'maintainer';
+}
+
+export interface TeamDefinition {
+  name: string;
+  description?: string;
+  members?: TeamMember[];
+  parent?: string;
+  privacy?: TeamPrivacy;
+  notification_setting?: TeamNotificationSetting;
+}
+
+export interface TeamMemberFilter {
+  usernames?: string[];
+  emails?: string[];
+  from_teams?: string[];
+  exclude_teams?: string[];
+  with_repo_access?: string[];
+}
+
+export interface TeamCompositionDifference {
+  from: string;
+  subtract: string[];
+}
+
+export interface TeamComposition {
+  union?: string[];
+  intersection?: string[];
+  difference?: TeamCompositionDifference;
+}
+
+export interface DynamicTeamRule {
+  name: string;
+  description?: string;
+  type: 'all_org_members' | 'by_filter' | 'composite';
+  filter?: TeamMemberFilter;
+  compose?: TeamComposition;
+}
+
+export type UnmanagedTeamsMode = 'ignore' | 'warn' | 'remove';
+
+export interface TeamsConfig {
+  definitions?: TeamDefinition[];
+  dynamic_rules?: DynamicTeamRule[];
+  dry_run?: boolean;
+  unmanaged_teams?: UnmanagedTeamsMode;
+}
+
 export interface ArchivedRepos {
   admin_team_only: boolean;
   archive_inactive?: boolean;
@@ -114,4 +168,5 @@ export interface ComplianceConfig {
   rules?: Rule[];
   checks?: Checks;
   cache?: CacheConfig;
+  teams?: TeamsConfig;
 }

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -63,6 +63,29 @@ export interface TeamPermission {
   permission: 'read' | 'triage' | 'write' | 'maintain' | 'admin';
 }
 
+export interface GitHubTeamSummary {
+  id: number;
+  name: string;
+  slug: string;
+  description?: string | null;
+  privacy?: 'closed' | 'secret';
+  notification_setting?: 'notifications_enabled' | 'notifications_disabled' | null;
+  parent?: {
+    id: number;
+    slug?: string | null;
+    name?: string | null;
+  } | null;
+}
+
+export interface GitHubTeamMember {
+  login: string;
+  role: 'member' | 'maintainer';
+}
+
+export interface OrganizationMember {
+  login: string;
+}
+
 export interface Collaborator {
   id: number;
   login: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export * from './config';
 export * from './github';
 export * from './reporting';
 export * from './runner';
+export * from './teams';

--- a/src/runner/__tests__/check-registry.test.ts
+++ b/src/runner/__tests__/check-registry.test.ts
@@ -9,12 +9,12 @@ import { getAvailableChecks, getCheck } from '../check-registry';
 describe('check-registry', () => {
   describe('getCheck', () => {
     it('should return the correct check class for valid check names', () => {
+      expect(getCheck('team-sync')).toBe(TeamSyncCheck);
       expect(getCheck('merge-methods')).toBe(MergeMethodsCheck);
       expect(getCheck('team-permissions')).toBe(TeamPermissionsCheck);
       expect(getCheck('branch-protection')).toBe(BranchProtectionCheck);
       expect(getCheck('security-scanning')).toBe(SecurityScanningCheck);
       expect(getCheck('archived-repos')).toBe(ArchivedReposCheck);
-      expect(getCheck('team-sync')).toBe(TeamSyncCheck);
     });
 
     it('should throw an error for unknown check names', () => {
@@ -36,12 +36,12 @@ describe('check-registry', () => {
       const availableChecks = getAvailableChecks();
 
       expect(availableChecks).toEqual([
+        'team-sync',
         'merge-methods',
         'team-permissions',
         'branch-protection',
         'security-scanning',
         'archived-repos',
-        'team-sync',
       ]);
     });
 

--- a/src/runner/__tests__/check-registry.test.ts
+++ b/src/runner/__tests__/check-registry.test.ts
@@ -3,6 +3,7 @@ import { BranchProtectionCheck } from '../../checks/branch-protection';
 import { MergeMethodsCheck } from '../../checks/merge-methods';
 import { SecurityScanningCheck } from '../../checks/security-scanning';
 import { TeamPermissionsCheck } from '../../checks/team-permissions';
+import { TeamSyncCheck } from '../../checks/team-sync';
 import { getAvailableChecks, getCheck } from '../check-registry';
 
 describe('check-registry', () => {
@@ -13,6 +14,7 @@ describe('check-registry', () => {
       expect(getCheck('branch-protection')).toBe(BranchProtectionCheck);
       expect(getCheck('security-scanning')).toBe(SecurityScanningCheck);
       expect(getCheck('archived-repos')).toBe(ArchivedReposCheck);
+      expect(getCheck('team-sync')).toBe(TeamSyncCheck);
     });
 
     it('should throw an error for unknown check names', () => {
@@ -39,6 +41,7 @@ describe('check-registry', () => {
         'branch-protection',
         'security-scanning',
         'archived-repos',
+        'team-sync',
       ]);
     });
 

--- a/src/runner/__tests__/check-registry.test.ts
+++ b/src/runner/__tests__/check-registry.test.ts
@@ -8,7 +8,16 @@ import { getAvailableChecks, getCheck } from '../check-registry';
 
 describe('check-registry', () => {
   describe('getCheck', () => {
-    it('should return the correct check class for valid check names', () => {
+    it('should return the correct check class for new check names', () => {
+      expect(getCheck('org-team-sync')).toBe(TeamSyncCheck);
+      expect(getCheck('repo-merge-strategy')).toBe(MergeMethodsCheck);
+      expect(getCheck('repo-access-teams')).toBe(TeamPermissionsCheck);
+      expect(getCheck('repo-branch-protection')).toBe(BranchProtectionCheck);
+      expect(getCheck('repo-security-controls')).toBe(SecurityScanningCheck);
+      expect(getCheck('repo-archival-policy')).toBe(ArchivedReposCheck);
+    });
+
+    it('should support legacy check name aliases', () => {
       expect(getCheck('team-sync')).toBe(TeamSyncCheck);
       expect(getCheck('merge-methods')).toBe(MergeMethodsCheck);
       expect(getCheck('team-permissions')).toBe(TeamPermissionsCheck);
@@ -36,12 +45,12 @@ describe('check-registry', () => {
       const availableChecks = getAvailableChecks();
 
       expect(availableChecks).toEqual([
-        'team-sync',
-        'merge-methods',
-        'team-permissions',
-        'branch-protection',
-        'security-scanning',
-        'archived-repos',
+        'org-team-sync',
+        'repo-merge-strategy',
+        'repo-access-teams',
+        'repo-branch-protection',
+        'repo-security-controls',
+        'repo-archival-policy',
       ]);
     });
 

--- a/src/runner/__tests__/runner.test.ts
+++ b/src/runner/__tests__/runner.test.ts
@@ -89,7 +89,7 @@ describe('ComplianceRunner', () => {
     const options: RunnerOptions = {
       dryRun: true,
       includeArchived: false,
-      checks: ['merge-methods'],
+      checks: ['repo-merge-strategy'],
     };
 
     const runner = new ComplianceRunner(mockClient as GitHubClient, mockConfig, options);
@@ -98,6 +98,18 @@ describe('ComplianceRunner', () => {
 
     expect(report).toHaveProperty('repositories');
     // Since we're using a mock, detailed assertions would depend on mock implementations
+  });
+
+  it('should normalize legacy check identifiers', async () => {
+    const options: RunnerOptions = {
+      dryRun: true,
+      includeArchived: false,
+      checks: ['merge-methods'],
+    };
+
+    const runner = new ComplianceRunner(mockClient as GitHubClient, mockConfig, options);
+
+    await expect(runner.run()).resolves.toHaveProperty('repositories');
   });
 
   it('should handle empty repository list', async () => {

--- a/src/runner/check-registry.ts
+++ b/src/runner/check-registry.ts
@@ -10,12 +10,12 @@ import type { CheckRegistry } from './types';
  * Registry of all available compliance checks
  */
 const checkRegistry: CheckRegistry = {
+  'team-sync': TeamSyncCheck,
   'merge-methods': MergeMethodsCheck,
   'team-permissions': TeamPermissionsCheck,
   'branch-protection': BranchProtectionCheck,
   'security-scanning': SecurityScanningCheck,
   'archived-repos': ArchivedReposCheck,
-  'team-sync': TeamSyncCheck,
 };
 
 /**

--- a/src/runner/check-registry.ts
+++ b/src/runner/check-registry.ts
@@ -3,6 +3,7 @@ import { BranchProtectionCheck } from '../checks/branch-protection';
 import { MergeMethodsCheck } from '../checks/merge-methods';
 import { SecurityScanningCheck } from '../checks/security-scanning';
 import { TeamPermissionsCheck } from '../checks/team-permissions';
+import { TeamSyncCheck } from '../checks/team-sync';
 import type { CheckRegistry } from './types';
 
 /**
@@ -14,6 +15,7 @@ const checkRegistry: CheckRegistry = {
   'branch-protection': BranchProtectionCheck,
   'security-scanning': SecurityScanningCheck,
   'archived-repos': ArchivedReposCheck,
+  'team-sync': TeamSyncCheck,
 };
 
 /**

--- a/src/runner/check-registry.ts
+++ b/src/runner/check-registry.ts
@@ -10,19 +10,33 @@ import type { CheckRegistry } from './types';
  * Registry of all available compliance checks
  */
 const checkRegistry: CheckRegistry = {
-  'team-sync': TeamSyncCheck,
-  'merge-methods': MergeMethodsCheck,
-  'team-permissions': TeamPermissionsCheck,
-  'branch-protection': BranchProtectionCheck,
-  'security-scanning': SecurityScanningCheck,
-  'archived-repos': ArchivedReposCheck,
+  'org-team-sync': TeamSyncCheck,
+  'repo-merge-strategy': MergeMethodsCheck,
+  'repo-access-teams': TeamPermissionsCheck,
+  'repo-branch-protection': BranchProtectionCheck,
+  'repo-security-controls': SecurityScanningCheck,
+  'repo-archival-policy': ArchivedReposCheck,
+};
+
+const legacyCheckAliases: Record<string, keyof typeof checkRegistry> = {
+  'team-sync': 'org-team-sync',
+  'merge-methods': 'repo-merge-strategy',
+  'team-permissions': 'repo-access-teams',
+  'branch-protection': 'repo-branch-protection',
+  'security-scanning': 'repo-security-controls',
+  'archived-repos': 'repo-archival-policy',
 };
 
 /**
  * Get a check class by name
  */
+export function normalizeCheckName(name: string): string {
+  return (legacyCheckAliases[name] ?? name) as string;
+}
+
 export function getCheck(name: string): new () => unknown {
-  const CheckClass = checkRegistry[name];
+  const normalized = normalizeCheckName(name) as keyof typeof checkRegistry;
+  const CheckClass = checkRegistry[normalized];
   if (!CheckClass) {
     throw new Error(`Unknown check: ${name}`);
   }

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -4,7 +4,7 @@ import type { GitHubClient } from '../github/client';
 import type { Repository } from '../github/types';
 import type { ProgressLogger } from '../logging';
 import * as logger from '../logging';
-import { getAvailableChecks, getCheck } from './check-registry';
+import { getAvailableChecks, getCheck, normalizeCheckName } from './check-registry';
 import type { CheckExecution, RepositoryReport, RunnerOptions, RunnerReport } from './types';
 
 export class ComplianceRunner {
@@ -148,14 +148,14 @@ export class ComplianceRunner {
       return availableChecks;
     }
 
-    // Validate requested checks
-    const invalidChecks = this.options.checks.filter((check) => !availableChecks.includes(check));
+    const normalizedChecks = this.options.checks.map((check) => normalizeCheckName(check));
+    const invalidChecks = normalizedChecks.filter((check) => !availableChecks.includes(check));
 
     if (invalidChecks.length > 0) {
       logger.warning(`Invalid checks requested: ${invalidChecks.join(', ')}`);
     }
 
-    return this.options.checks.filter((check) => availableChecks.includes(check));
+    return normalizedChecks.filter((check) => availableChecks.includes(check));
   }
 
   /**

--- a/src/teams/__tests__/diff.test.ts
+++ b/src/teams/__tests__/diff.test.ts
@@ -1,0 +1,41 @@
+import type { TeamDefinition } from '../../config/types';
+import type { GitHubClient } from '../../github';
+import { calculateTeamDiff } from '../diff';
+
+describe('teams/diff', () => {
+  const github = {} as unknown as GitHubClient;
+
+  it('includes new members and metadata changes', async () => {
+    const definition: TeamDefinition = {
+      name: 'platform',
+      description: 'Platform team',
+      privacy: 'closed',
+      parent: 'engineering',
+      members: [{ username: 'octocat', role: 'maintainer' }, { username: 'hubot' }],
+    };
+
+    const diff = await calculateTeamDiff(github, definition);
+
+    expect(diff.team).toBe('platform');
+    expect(diff.exists).toBe(false);
+    expect(diff.changes.description).toEqual({ new: 'Platform team' });
+    expect(diff.changes.privacy).toEqual({ new: 'closed' });
+    expect(diff.changes.parent).toEqual({ new: 'engineering' });
+    expect(diff.changes.membersToAdd).toHaveLength(2);
+    expect(diff.changes.membersToRemove).toEqual([]);
+    expect(diff.changes.membersToUpdateRole).toEqual([]);
+  });
+
+  it('omits optional metadata when not provided', async () => {
+    const definition: TeamDefinition = {
+      name: 'support',
+    };
+
+    const diff = await calculateTeamDiff(github, definition);
+
+    expect(diff.changes.description).toBeUndefined();
+    expect(diff.changes.privacy).toBeUndefined();
+    expect(diff.changes.parent).toBeUndefined();
+    expect(diff.changes.membersToAdd).toEqual([]);
+  });
+});

--- a/src/teams/__tests__/dynamic.test.ts
+++ b/src/teams/__tests__/dynamic.test.ts
@@ -1,0 +1,51 @@
+import type { TeamsConfig } from '../../config/types';
+import type { GitHubClient } from '../../github';
+import type { Logger } from '../../logging';
+import { resolveTeams } from '../dynamic';
+
+describe('teams/dynamic', () => {
+  const github = {} as unknown as GitHubClient;
+
+  const logger: Logger = {
+    info: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    startGroup: jest.fn(),
+    endGroup: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns static and dynamic teams', async () => {
+    const config: TeamsConfig = {
+      definitions: [{ name: 'platform', members: [{ username: 'octocat' }] }],
+      dynamic_rules: [{ name: 'all-members', type: 'all_org_members' }],
+    };
+
+    const resolved = await resolveTeams(github, config, { logger, dryRun: true });
+
+    expect(resolved.staticTeams).toHaveLength(1);
+    expect(resolved.staticTeams[0]?.definition.name).toBe('platform');
+    expect(resolved.staticTeams[0]?.members).toEqual([{ username: 'octocat' }]);
+
+    expect(resolved.dynamicTeams).toHaveLength(1);
+    expect(resolved.dynamicTeams[0]?.definition.name).toBe('all-members');
+    expect(resolved.dynamicTeams[0]?.rule?.name).toBe('all-members');
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Dynamic team rules detected but the resolution engine is not implemented yet.'
+    );
+  });
+
+  it('handles missing team definitions gracefully', async () => {
+    const config: TeamsConfig = {};
+
+    const resolved = await resolveTeams(github, config, { logger, dryRun: false });
+
+    expect(resolved.staticTeams).toEqual([]);
+    expect(resolved.dynamicTeams).toEqual([]);
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+});

--- a/src/teams/__tests__/dynamic.test.ts
+++ b/src/teams/__tests__/dynamic.test.ts
@@ -41,8 +41,8 @@ describe('teams/dynamic', () => {
 
     const config: TeamsConfig = {
       dynamic_rules: [
-        { name: 'filter-rule', type: 'by_filter' },
-        { name: 'composite-rule', type: 'composite' },
+        { name: 'filter-rule', type: 'by_filter', filter: { usernames: ['octocat'] } },
+        { name: 'composite-rule', type: 'composite', compose: { union: ['team-a'] } },
       ],
     };
 

--- a/src/teams/__tests__/sync.test.ts
+++ b/src/teams/__tests__/sync.test.ts
@@ -1,0 +1,43 @@
+import type { GitHubClient } from '../../github';
+import type { Logger } from '../../logging';
+import { applyTeamDiffs } from '../sync';
+import type { TeamDiff } from '../types';
+
+describe('teams/sync', () => {
+  const github = {} as unknown as GitHubClient;
+
+  const logger: Logger = {
+    info: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    startGroup: jest.fn(),
+    endGroup: jest.fn(),
+  };
+
+  const diff: TeamDiff = {
+    team: 'platform',
+    exists: false,
+    changes: {
+      membersToAdd: [],
+      membersToRemove: [],
+      membersToUpdateRole: [],
+    },
+  };
+
+  it('logs a warning when synchronization is not implemented in dry run', async () => {
+    await applyTeamDiffs(github, diff, { logger, dryRun: true });
+
+    expect(logger.warning).toHaveBeenCalledWith(
+      '[dry-run] Team synchronization for platform is not implemented; skipping apply step.'
+    );
+  });
+
+  it('logs a warning when synchronization is not implemented for real changes', async () => {
+    await applyTeamDiffs(github, diff, { logger, dryRun: false });
+
+    expect(logger.warning).toHaveBeenCalledWith(
+      'Team synchronization for platform is not implemented; skipping apply step.'
+    );
+  });
+});

--- a/src/teams/__tests__/team-manager.test.ts
+++ b/src/teams/__tests__/team-manager.test.ts
@@ -1,0 +1,49 @@
+import type { TeamsConfig } from '../../config/types';
+import type { GitHubClient } from '../../github';
+import type { Logger } from '../../logging';
+import { TeamManager } from '../manager';
+
+const noop = (): void => {
+  /* intentional no-op */
+};
+
+const testLogger: Logger = {
+  info: noop,
+  warning: noop,
+  error: noop,
+  debug: noop,
+  startGroup: noop,
+  endGroup: noop,
+};
+
+describe('TeamManager', () => {
+  const github = {} as unknown as GitHubClient;
+
+  it('returns an empty result when no config is provided', async () => {
+    const manager = new TeamManager(github, undefined, testLogger);
+    const result = await manager.sync();
+
+    expect(result.hasChanges).toBe(false);
+    expect(result.stats.processed).toBe(0);
+    expect(result.summary).toContain('No team configuration');
+  });
+
+  it('reports that synchronization is not implemented yet', async () => {
+    const config: TeamsConfig = {
+      definitions: [
+        {
+          name: 'platform',
+          members: [{ username: 'octocat' }],
+        },
+      ],
+    };
+
+    const manager = new TeamManager(github, config, testLogger);
+    const result = await manager.sync();
+
+    expect(result.stats.processed).toBe(1);
+    expect(result.summary).toContain('not yet implemented');
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]?.level).toBe('info');
+  });
+});

--- a/src/teams/__tests__/team-manager.test.ts
+++ b/src/teams/__tests__/team-manager.test.ts
@@ -1,5 +1,6 @@
 import type { TeamsConfig } from '../../config/types';
 import type { GitHubClient } from '../../github';
+import type { GitHubTeamSummary } from '../../github/types';
 import type { Logger } from '../../logging';
 import { TeamManager } from '../manager';
 
@@ -8,19 +9,61 @@ const noop = (): void => {
 };
 
 const testLogger: Logger = {
-  info: noop,
-  warning: noop,
-  error: noop,
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
   debug: noop,
   startGroup: noop,
   endGroup: noop,
 };
 
 describe('TeamManager', () => {
-  const github = {} as unknown as GitHubClient;
+  const baseGithub = {
+    getOwner: jest.fn().mockReturnValue('test-org'),
+    listOrganizationTeams: jest.fn().mockResolvedValue([]),
+    listOrganizationMembers: jest.fn().mockResolvedValue([{ login: 'octocat' }]),
+    listTeamMembers: jest.fn().mockResolvedValue([]),
+    createTeam: jest.fn().mockResolvedValue({
+      id: 101,
+      name: 'all',
+      slug: 'all',
+      description: 'All members',
+      privacy: 'closed',
+      notification_setting: 'notifications_enabled',
+      parent: null,
+    } satisfies GitHubTeamSummary),
+    updateTeam: jest.fn(),
+    addOrUpdateTeamMembership: jest.fn(),
+    removeTeamMembership: jest.fn(),
+    getTeamBySlug: jest.fn().mockResolvedValue({
+      id: 101,
+      slug: 'all',
+      name: 'all',
+      description: 'All members',
+      privacy: 'closed',
+      notification_setting: 'notifications_enabled',
+      parent: null,
+    }),
+  } as unknown as GitHubClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (baseGithub.getOwner as jest.Mock).mockReturnValue('test-org');
+    (baseGithub.listOrganizationTeams as jest.Mock).mockResolvedValue([]);
+    (baseGithub.listOrganizationMembers as jest.Mock).mockResolvedValue([{ login: 'octocat' }]);
+    (baseGithub.createTeam as jest.Mock).mockResolvedValue({
+      id: 101,
+      name: 'all',
+      slug: 'all',
+      description: 'All members',
+      privacy: 'closed',
+      notification_setting: 'notifications_enabled',
+      parent: null,
+    });
+  });
 
   it('returns an empty result when no config is provided', async () => {
-    const manager = new TeamManager(github, undefined, testLogger);
+    const manager = new TeamManager(baseGithub, undefined, testLogger);
     const result = await manager.sync();
 
     expect(result.hasChanges).toBe(false);
@@ -28,22 +71,136 @@ describe('TeamManager', () => {
     expect(result.summary).toContain('No team configuration');
   });
 
-  it('reports that synchronization is not implemented yet', async () => {
+  it('performs dry-run synchronization for dynamic all-org-members rule', async () => {
     const config: TeamsConfig = {
-      definitions: [
+      dynamic_rules: [
         {
-          name: 'platform',
-          members: [{ username: 'octocat' }],
+          name: 'all',
+          type: 'all_org_members',
+        },
+      ],
+      dry_run: true,
+    };
+
+    const manager = new TeamManager(baseGithub, config, testLogger, { dryRun: true });
+    const result = await manager.sync();
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.stats.created).toBeGreaterThanOrEqual(1);
+    expect(baseGithub.createTeam).not.toHaveBeenCalled();
+  });
+
+  it('creates team and adds members when not in dry-run', async () => {
+    const config: TeamsConfig = {
+      dynamic_rules: [
+        {
+          name: 'all',
+          type: 'all_org_members',
+          description: 'All organization members',
         },
       ],
     };
 
-    const manager = new TeamManager(github, config, testLogger);
+    const manager = new TeamManager(baseGithub, config, testLogger, { dryRun: false });
     const result = await manager.sync();
 
-    expect(result.stats.processed).toBe(1);
-    expect(result.summary).toContain('not yet implemented');
-    expect(result.findings).toHaveLength(1);
-    expect(result.findings[0]?.level).toBe('info');
+    expect(baseGithub.createTeam).toHaveBeenCalledWith(
+      'test-org',
+      expect.objectContaining({ name: 'all', description: 'All organization members' })
+    );
+    expect(baseGithub.addOrUpdateTeamMembership).toHaveBeenCalledWith(
+      'test-org',
+      'all',
+      'octocat',
+      'member'
+    );
+    expect(result.stats.created).toBeGreaterThanOrEqual(1);
+  });
+
+  it('updates existing team metadata and memberships', async () => {
+    (baseGithub.listOrganizationTeams as jest.Mock).mockResolvedValue([
+      {
+        id: 10,
+        name: 'platform',
+        slug: 'platform',
+        description: 'Old description',
+        privacy: 'secret',
+        notification_setting: 'notifications_enabled',
+        parent: null,
+      },
+    ] satisfies GitHubTeamSummary[]);
+    (baseGithub.listTeamMembers as jest.Mock).mockResolvedValue([
+      { login: 'octocat', role: 'member' },
+      { login: 'hubot', role: 'maintainer' },
+    ]);
+
+    const config: TeamsConfig = {
+      definitions: [
+        {
+          name: 'platform',
+          description: 'New description',
+          privacy: 'closed',
+          notification_setting: 'notifications_disabled',
+          members: [{ username: 'octocat', role: 'maintainer' }],
+        },
+      ],
+    };
+
+    const manager = new TeamManager(baseGithub, config, testLogger);
+    const result = await manager.sync();
+
+    expect(baseGithub.updateTeam).toHaveBeenCalledWith(
+      'test-org',
+      'platform',
+      expect.objectContaining({
+        name: 'platform',
+        notification_setting: 'notifications_disabled',
+      })
+    );
+    expect(baseGithub.addOrUpdateTeamMembership).toHaveBeenCalledWith(
+      'test-org',
+      'platform',
+      'octocat',
+      'maintainer'
+    );
+    expect(baseGithub.removeTeamMembership).toHaveBeenCalledWith('test-org', 'platform', 'hubot');
+    expect(result.stats.updated).toBeGreaterThanOrEqual(1);
+  });
+
+  it('returns error when organization owner is missing', async () => {
+    const github = {
+      getOwner: jest.fn().mockReturnValue(undefined),
+    } as unknown as GitHubClient;
+
+    const manager = new TeamManager(github, { definitions: [] }, testLogger);
+    const result = await manager.sync();
+
+    expect(result.hasErrors).toBe(true);
+    expect(result.summary).toContain('missing organization owner');
+  });
+
+  it('warns about unmanaged teams when configured', async () => {
+    (baseGithub.listOrganizationTeams as jest.Mock).mockResolvedValue([
+      {
+        id: 20,
+        name: 'legacy',
+        slug: 'legacy',
+        description: 'Legacy team',
+        privacy: 'closed',
+        notification_setting: 'notifications_enabled',
+        parent: null,
+      },
+    ] satisfies GitHubTeamSummary[]);
+
+    const config: TeamsConfig = {
+      definitions: [{ name: 'platform' }],
+      unmanaged_teams: 'warn',
+      dry_run: true,
+    };
+
+    const manager = new TeamManager(baseGithub, config, testLogger, { dryRun: true });
+    const result = await manager.sync();
+
+    expect(result.findings.some((f) => f.level === 'warning')).toBe(true);
   });
 });

--- a/src/teams/diff.ts
+++ b/src/teams/diff.ts
@@ -1,32 +1,165 @@
-import type { TeamDefinition } from '../config/types';
-import type { GitHubClient } from '../github';
-import type { TeamDiff } from './types';
+import type { TeamDefinition, TeamMember } from '../config/types';
+import type { GitHubTeamState, TeamDiff } from './types';
 
-export async function calculateTeamDiff(
-  _github: GitHubClient,
-  definition: TeamDefinition
-): Promise<TeamDiff> {
-  const changes: TeamDiff['changes'] = {
-    membersToAdd: definition.members ?? [],
-    membersToRemove: [],
-    membersToUpdateRole: [],
-  };
+interface CalculateTeamDiffParams {
+  definition: TeamDefinition;
+  slug: string;
+  targetMembers: TeamMember[];
+  manageMembers: boolean;
+  existingTeam: GitHubTeamState | null;
+  parentTeamId?: number | null;
+  targetParentSlug?: string | null;
+}
 
-  if (definition.description !== undefined) {
-    changes.description = { new: definition.description };
+function normalizeString(value?: string | null): string | null {
+  if (value === undefined || value === null || value.trim() === '') {
+    return null;
+  }
+  return value.trim();
+}
+
+function normalizeNotificationSetting(
+  value?: 'notifications_enabled' | 'notifications_disabled' | null
+): 'notifications_enabled' | 'notifications_disabled' | null {
+  if (!value) {
+    return null;
+  }
+  return value;
+}
+
+function compareMembers(
+  currentMembers: TeamMember[],
+  targetMembers: TeamMember[],
+  manageMembers: boolean
+): {
+  membersToAdd: TeamMember[];
+  membersToRemove: string[];
+  membersToUpdateRole: { username: string; newRole: 'member' | 'maintainer' }[];
+} {
+  if (!manageMembers) {
+    return {
+      membersToAdd: [],
+      membersToRemove: [],
+      membersToUpdateRole: [],
+    };
   }
 
-  if (definition.privacy !== undefined) {
-    changes.privacy = { new: definition.privacy };
+  const currentMap = new Map<string, TeamMember>();
+  for (const member of currentMembers) {
+    currentMap.set(member.username.toLowerCase(), member);
   }
 
-  if (definition.parent !== undefined) {
-    changes.parent = { new: definition.parent ?? null };
+  const targetMap = new Map<string, TeamMember>();
+  for (const member of targetMembers) {
+    targetMap.set(member.username.toLowerCase(), member);
   }
 
-  return {
+  const membersToAdd: TeamMember[] = [];
+  const membersToRemove: string[] = [];
+  const membersToUpdateRole: { username: string; newRole: 'member' | 'maintainer' }[] = [];
+
+  for (const [username, targetMember] of targetMap.entries()) {
+    const existing = currentMap.get(username);
+    if (!existing) {
+      membersToAdd.push(targetMember);
+      continue;
+    }
+
+    const existingRole = existing.role ?? 'member';
+    const desiredRole = targetMember.role ?? 'member';
+    if (existingRole !== desiredRole) {
+      membersToUpdateRole.push({ username: targetMember.username, newRole: desiredRole });
+    }
+  }
+
+  for (const [username, member] of currentMap.entries()) {
+    if (!targetMap.has(username)) {
+      membersToRemove.push(member.username);
+    }
+  }
+
+  return { membersToAdd, membersToRemove, membersToUpdateRole };
+}
+
+export function calculateTeamDiff({
+  definition,
+  slug,
+  targetMembers,
+  manageMembers,
+  existingTeam,
+  parentTeamId,
+  targetParentSlug,
+}: CalculateTeamDiffParams): TeamDiff {
+  const currentDescription = normalizeString(existingTeam?.description);
+  const targetDescription = normalizeString(definition.description ?? null);
+
+  const currentPrivacy = existingTeam?.privacy ?? null;
+  const targetPrivacy: 'closed' | 'secret' = definition.privacy
+    ? definition.privacy
+    : existingTeam && currentPrivacy
+      ? currentPrivacy
+      : 'closed';
+
+  const currentParent = existingTeam?.parent ?? null;
+  const parentSlug = targetParentSlug ?? (definition.parent ? definition.parent : null);
+
+  const currentNotification = normalizeNotificationSetting(
+    existingTeam?.notification_setting ?? null
+  );
+  const targetNotification = normalizeNotificationSetting(
+    definition.notification_setting ?? (existingTeam ? currentNotification : null)
+  );
+
+  const membersDiff = compareMembers(existingTeam?.members ?? [], targetMembers, manageMembers);
+
+  const changes = {
+    membersToAdd: membersDiff.membersToAdd,
+    membersToRemove: membersDiff.membersToRemove,
+    membersToUpdateRole: membersDiff.membersToUpdateRole,
+  } as TeamDiff['changes'];
+
+  if (currentDescription !== targetDescription) {
+    changes.description = {
+      old: currentDescription ?? null,
+      new: targetDescription ?? null,
+    };
+  }
+
+  if (currentPrivacy !== targetPrivacy) {
+    changes.privacy = {
+      old: currentPrivacy ?? null,
+      new: targetPrivacy,
+    };
+  }
+
+  if (currentParent !== parentSlug) {
+    changes.parent = {
+      old: currentParent ?? null,
+      new: parentSlug ?? null,
+    };
+  }
+
+  if (currentNotification !== targetNotification) {
+    changes.notification_setting = {
+      old: currentNotification,
+      new: targetNotification ?? null,
+    };
+  }
+
+  const diff: TeamDiff = {
     team: definition.name,
-    exists: false,
+    slug,
+    exists: existingTeam !== null,
+    definition,
+    targetMembers,
+    manageMembers,
+    targetParentId: parentTeamId ?? null,
     changes,
   };
+
+  if (existingTeam?.id !== undefined) {
+    diff.teamId = existingTeam.id;
+  }
+
+  return diff;
 }

--- a/src/teams/diff.ts
+++ b/src/teams/diff.ts
@@ -1,0 +1,32 @@
+import type { TeamDefinition } from '../config/types';
+import type { GitHubClient } from '../github';
+import type { TeamDiff } from './types';
+
+export async function calculateTeamDiff(
+  _github: GitHubClient,
+  definition: TeamDefinition
+): Promise<TeamDiff> {
+  const changes: TeamDiff['changes'] = {
+    membersToAdd: definition.members ?? [],
+    membersToRemove: [],
+    membersToUpdateRole: [],
+  };
+
+  if (definition.description !== undefined) {
+    changes.description = { new: definition.description };
+  }
+
+  if (definition.privacy !== undefined) {
+    changes.privacy = { new: definition.privacy };
+  }
+
+  if (definition.parent !== undefined) {
+    changes.parent = { new: definition.parent ?? null };
+  }
+
+  return {
+    team: definition.name,
+    exists: false,
+    changes,
+  };
+}

--- a/src/teams/dynamic.ts
+++ b/src/teams/dynamic.ts
@@ -68,6 +68,7 @@ export async function resolveTeams(
   }
 
   for (const rule of config.dynamic_rules) {
+    const ruleName = rule.name;
     switch (rule.type) {
       case 'all_org_members': {
         const team = await resolveAllOrgMembers(github, owner, rule, options.logger);
@@ -78,19 +79,19 @@ export async function resolveTeams(
       }
       case 'by_filter': {
         options.logger.warning(
-          `Dynamic rule ${rule.name} uses unsupported type 'by_filter' and will be skipped.`
+          `Dynamic rule ${ruleName} uses unsupported type 'by_filter' and will be skipped.`
         );
         break;
       }
       case 'composite': {
         options.logger.warning(
-          `Dynamic rule ${rule.name} uses unsupported type 'composite' and will be skipped.`
+          `Dynamic rule ${ruleName} uses unsupported type 'composite' and will be skipped.`
         );
         break;
       }
       default: {
         options.logger.warning(
-          `Dynamic rule ${rule.name} has unknown type ${(rule as { type: unknown }).type}`
+          `Dynamic rule ${ruleName} has unknown type ${(rule as { type: unknown }).type}`
         );
       }
     }

--- a/src/teams/dynamic.ts
+++ b/src/teams/dynamic.ts
@@ -1,0 +1,55 @@
+import type { DynamicTeamRule, TeamDefinition, TeamsConfig } from '../config/types';
+import type { GitHubClient } from '../github';
+import type { Logger } from '../logging';
+import type { ResolvedTeam, ResolvedTeams } from './types';
+
+interface ResolveTeamsOptions {
+  logger: Logger;
+  dryRun: boolean;
+}
+
+function createPlaceholderTeamFromRule(rule: DynamicTeamRule): TeamDefinition {
+  const definition: TeamDefinition = {
+    name: rule.name,
+  };
+
+  if (rule.description) {
+    definition.description = rule.description;
+  }
+
+  return definition;
+}
+
+function convertStaticDefinitions(definitions: TeamDefinition[] | undefined): ResolvedTeam[] {
+  return (definitions ?? []).map((definition) => ({
+    definition,
+    members: definition.members ?? [],
+    source: 'definition' as const,
+  }));
+}
+
+function convertDynamicRules(rules: DynamicTeamRule[] | undefined): ResolvedTeam[] {
+  return (rules ?? []).map((rule) => ({
+    definition: createPlaceholderTeamFromRule(rule),
+    members: [],
+    source: 'dynamic' as const,
+    rule,
+  }));
+}
+
+export async function resolveTeams(
+  _github: GitHubClient,
+  config: TeamsConfig,
+  options: ResolveTeamsOptions
+): Promise<ResolvedTeams> {
+  const staticTeams = convertStaticDefinitions(config.definitions);
+  const dynamicTeams = convertDynamicRules(config.dynamic_rules);
+
+  if (dynamicTeams.length > 0) {
+    options.logger.debug(
+      'Dynamic team rules detected but the resolution engine is not implemented yet.'
+    );
+  }
+
+  return { staticTeams, dynamicTeams };
+}

--- a/src/teams/index.ts
+++ b/src/teams/index.ts
@@ -1,0 +1,2 @@
+export * from './manager';
+export * from './types';

--- a/src/teams/manager.ts
+++ b/src/teams/manager.ts
@@ -1,0 +1,99 @@
+import type { TeamDefinition, TeamsConfig } from '../config/types';
+import type { GitHubClient } from '../github';
+import type { Logger } from '../logging';
+import { calculateTeamDiff } from './diff';
+import { resolveTeams } from './dynamic';
+import { applyTeamDiffs } from './sync';
+import type { ResolvedTeams, SyncResult, TeamDiff, TeamSyncOptions } from './types';
+
+const EMPTY_RESULT: SyncResult = {
+  hasChanges: false,
+  hasErrors: false,
+  findings: [],
+  summary: 'No team configuration defined; skipping synchronization.',
+  stats: {
+    processed: 0,
+    created: 0,
+    updated: 0,
+    removed: 0,
+    skipped: 0,
+  },
+};
+
+export class TeamManager {
+  constructor(
+    private readonly github: GitHubClient,
+    private readonly config: TeamsConfig | undefined,
+    private readonly logger: Logger,
+    private readonly options: TeamSyncOptions = {}
+  ) {}
+
+  async sync(): Promise<SyncResult> {
+    if (!this.config) {
+      return EMPTY_RESULT;
+    }
+
+    const resolved = await this.resolveDynamicRules();
+    const totalTeams = resolved.staticTeams.length + resolved.dynamicTeams.length;
+
+    if (totalTeams === 0) {
+      return {
+        ...EMPTY_RESULT,
+        summary: 'No teams defined in configuration; nothing to sync.',
+        stats: {
+          processed: 0,
+          created: 0,
+          updated: 0,
+          removed: 0,
+          skipped: 0,
+        },
+      };
+    }
+
+    this.logger.warning(
+      'Team synchronization is under active development. No changes were applied during this run.'
+    );
+
+    return {
+      hasChanges: false,
+      hasErrors: false,
+      findings: [
+        {
+          level: 'info',
+          message: 'Resolved team configuration without applying changes.',
+          details: { totalTeams },
+        },
+      ],
+      summary: `Team synchronization is not yet implemented (${totalTeams} team configurations detected).`,
+      stats: {
+        processed: totalTeams,
+        created: 0,
+        updated: 0,
+        removed: 0,
+        skipped: totalTeams,
+      },
+    };
+  }
+
+  async getTeamDiff(teamDef: TeamDefinition): Promise<TeamDiff> {
+    return calculateTeamDiff(this.github, teamDef);
+  }
+
+  async applyTeamChanges(diff: TeamDiff): Promise<void> {
+    await applyTeamDiffs(this.github, diff, {
+      dryRun: this.options.dryRun ?? this.config?.dry_run ?? false,
+      logger: this.logger,
+    });
+  }
+
+  async resolveDynamicRules(): Promise<ResolvedTeams> {
+    if (!this.config) {
+      return { staticTeams: [], dynamicTeams: [] };
+    }
+
+    return resolveTeams(this.github, this.config, {
+      logger: this.logger,
+      dryRun: this.options.dryRun ?? this.config.dry_run ?? false,
+    });
+  }
+}

--- a/src/teams/manager.ts
+++ b/src/teams/manager.ts
@@ -1,10 +1,18 @@
-import type { TeamDefinition, TeamsConfig } from '../config/types';
+import type { TeamDefinition, TeamMember, TeamsConfig } from '../config/types';
 import type { GitHubClient } from '../github';
+import type { GitHubTeamMember, GitHubTeamSummary } from '../github/types';
 import type { Logger } from '../logging';
 import { calculateTeamDiff } from './diff';
 import { resolveTeams } from './dynamic';
 import { applyTeamDiffs } from './sync';
-import type { ResolvedTeams, SyncResult, TeamDiff, TeamSyncOptions } from './types';
+import type {
+  GitHubTeamState,
+  ResolvedTeams,
+  SyncFinding,
+  SyncResult,
+  TeamDiff,
+  TeamSyncOptions,
+} from './types';
 
 const EMPTY_RESULT: SyncResult = {
   hasChanges: false,
@@ -20,6 +28,64 @@ const EMPTY_RESULT: SyncResult = {
   },
 };
 
+function slugifyTeamName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-\s]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function mapGitHubMembers(members: GitHubTeamMember[]): TeamMember[] {
+  return members.map((member) => ({
+    username: member.login,
+    role: member.role,
+  }));
+}
+
+function buildTeamState(summary: GitHubTeamSummary, members: TeamMember[]): GitHubTeamState {
+  const state: GitHubTeamState = {
+    id: summary.id,
+    name: summary.name,
+    slug: summary.slug,
+    description: summary.description ?? null,
+    parent: summary.parent?.slug ?? null,
+    members,
+  };
+
+  if (summary.privacy) {
+    state.privacy = summary.privacy;
+  }
+  if (summary.notification_setting ?? null) {
+    state.notification_setting = summary.notification_setting ?? null;
+  }
+
+  return state;
+}
+
+function hasTeamChanges(diff: TeamDiff): boolean {
+  if (!diff.exists) {
+    return true;
+  }
+
+  const { changes, manageMembers } = diff;
+  if (changes.description || changes.privacy || changes.parent || changes.notification_setting) {
+    return true;
+  }
+
+  if (!manageMembers) {
+    return false;
+  }
+
+  return (
+    changes.membersToAdd.length > 0 ||
+    changes.membersToRemove.length > 0 ||
+    changes.membersToUpdateRole.length > 0
+  );
+}
+
 export class TeamManager {
   constructor(
     private readonly github: GitHubClient,
@@ -28,72 +94,324 @@ export class TeamManager {
     private readonly options: TeamSyncOptions = {}
   ) {}
 
+  private getOwner(): string | undefined {
+    return this.options.owner ?? this.github.getOwner();
+  }
+
+  private async resolveDynamicRules(owner: string): Promise<ResolvedTeams> {
+    return resolveTeams(
+      this.github,
+      this.config ?? {},
+      {
+        logger: this.logger,
+        dryRun: this.options.dryRun ?? this.config?.dry_run ?? false,
+      },
+      owner
+    );
+  }
+
+  private async fetchExistingTeams(owner: string): Promise<Map<string, GitHubTeamSummary>> {
+    const summaries = await this.github.listOrganizationTeams(owner);
+    const map = new Map<string, GitHubTeamSummary>();
+    for (const summary of summaries) {
+      map.set(summary.slug, summary);
+    }
+    return map;
+  }
+
+  private async buildExistingTeamState(
+    owner: string,
+    summary: GitHubTeamSummary | undefined
+  ): Promise<GitHubTeamState | null> {
+    if (!summary) {
+      return null;
+    }
+
+    const members = await this.github.listTeamMembers(owner, summary.slug);
+    return buildTeamState(summary, mapGitHubMembers(members));
+  }
+
+  private determineTargetMembers(
+    team: TeamDefinition,
+    members: TeamMember[]
+  ): {
+    members: TeamMember[];
+    manageMembers: boolean;
+  } {
+    if (members.length > 0) {
+      return { members, manageMembers: true };
+    }
+
+    if (team.members && team.members.length > 0) {
+      return { members: team.members, manageMembers: true };
+    }
+
+    if (team.members && team.members.length === 0) {
+      return { members: [], manageMembers: true };
+    }
+
+    return { members: [], manageMembers: false };
+  }
+
+  private recordFinding(
+    findings: SyncFinding[],
+    level: 'info' | 'warning' | 'error',
+    message: string,
+    team?: string,
+    details?: Record<string, unknown>
+  ): void {
+    const finding: SyncFinding = {
+      level,
+      message,
+    };
+    if (team !== undefined) {
+      finding.team = team;
+    }
+    if (details !== undefined) {
+      finding.details = details;
+    }
+    findings.push(finding);
+  }
+
   async sync(): Promise<SyncResult> {
     if (!this.config) {
       return EMPTY_RESULT;
     }
 
-    const resolved = await this.resolveDynamicRules();
-    const totalTeams = resolved.staticTeams.length + resolved.dynamicTeams.length;
-
-    if (totalTeams === 0) {
+    const owner = this.getOwner();
+    if (!owner) {
+      this.logger.error('Cannot synchronize teams: organization owner is not set.');
       return {
-        ...EMPTY_RESULT,
-        summary: 'No teams defined in configuration; nothing to sync.',
-        stats: {
-          processed: 0,
-          created: 0,
-          updated: 0,
-          removed: 0,
-          skipped: 0,
-        },
+        hasChanges: false,
+        hasErrors: true,
+        findings: [
+          {
+            level: 'error',
+            message: 'Organization owner is required to synchronize teams.',
+          },
+        ],
+        summary: 'Failed to synchronize teams: missing organization owner.',
+        stats: { ...EMPTY_RESULT.stats },
       };
     }
 
-    this.logger.warning(
-      'Team synchronization is under active development. No changes were applied during this run.'
-    );
+    const dryRun = this.options.dryRun ?? this.config.dry_run ?? false;
 
-    return {
-      hasChanges: false,
-      hasErrors: false,
-      findings: [
-        {
-          level: 'info',
-          message: 'Resolved team configuration without applying changes.',
-          details: { totalTeams },
-        },
-      ],
-      summary: `Team synchronization is not yet implemented (${totalTeams} team configurations detected).`,
-      stats: {
-        processed: totalTeams,
-        created: 0,
-        updated: 0,
-        removed: 0,
-        skipped: totalTeams,
-      },
+    const findings: SyncFinding[] = [];
+    const stats = {
+      processed: 0,
+      created: 0,
+      updated: 0,
+      removed: 0,
+      skipped: 0,
     };
-  }
 
-  async getTeamDiff(teamDef: TeamDefinition): Promise<TeamDiff> {
-    return calculateTeamDiff(this.github, teamDef);
-  }
+    let hasChanges = false;
+    let hasErrors = false;
 
-  async applyTeamChanges(diff: TeamDiff): Promise<void> {
-    await applyTeamDiffs(this.github, diff, {
-      dryRun: this.options.dryRun ?? this.config?.dry_run ?? false,
-      logger: this.logger,
-    });
-  }
-
-  async resolveDynamicRules(): Promise<ResolvedTeams> {
-    if (!this.config) {
-      return { staticTeams: [], dynamicTeams: [] };
+    let resolved: ResolvedTeams;
+    try {
+      resolved = await this.resolveDynamicRules(owner);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to resolve dynamic team rules: ${message}`);
+      return {
+        hasChanges: false,
+        hasErrors: true,
+        findings: [
+          {
+            level: 'error',
+            message: 'Failed to resolve dynamic team rules.',
+            details: { error: message },
+          },
+        ],
+        summary: 'Failed to synchronize teams due to dynamic rule resolution error.',
+        stats: { ...EMPTY_RESULT.stats },
+      };
     }
 
-    return resolveTeams(this.github, this.config, {
-      logger: this.logger,
-      dryRun: this.options.dryRun ?? this.config.dry_run ?? false,
-    });
+    const teamsToProcess = [
+      ...(this.config.definitions?.map((definition) => ({
+        definition,
+        members: definition.members ?? [],
+        source: 'definition' as const,
+      })) ?? []),
+      ...resolved.dynamicTeams,
+    ];
+
+    if (teamsToProcess.length === 0) {
+      return {
+        hasChanges: false,
+        hasErrors: false,
+        findings,
+        summary: 'No teams defined in configuration; nothing to synchronize.',
+        stats,
+      };
+    }
+
+    let existingTeamsMap: Map<string, GitHubTeamSummary>;
+    try {
+      existingTeamsMap = await this.fetchExistingTeams(owner);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to list teams for ${owner}: ${message}`);
+      return {
+        hasChanges: false,
+        hasErrors: true,
+        findings: [
+          {
+            level: 'error',
+            message: 'Failed to retrieve existing teams from GitHub.',
+            details: { error: message },
+          },
+        ],
+        summary: 'Failed to synchronize teams due to GitHub API error.',
+        stats,
+      };
+    }
+
+    for (const team of teamsToProcess) {
+      stats.processed += 1;
+
+      const slug = slugifyTeamName(team.definition.name);
+      const existingSummary = existingTeamsMap.get(slug);
+      let existingState: GitHubTeamState | null = null;
+
+      try {
+        existingState = await this.buildExistingTeamState(owner, existingSummary);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.error(`Failed to load current state for team ${slug}: ${message}`);
+        hasErrors = true;
+        this.recordFinding(
+          findings,
+          'error',
+          'Failed to load current team state.',
+          team.definition.name,
+          {
+            error: message,
+          }
+        );
+        continue;
+      }
+
+      const parentSlug = team.definition.parent ? slugifyTeamName(team.definition.parent) : null;
+      let parentTeamId: number | null | undefined;
+      if (parentSlug) {
+        const parentSummary = existingTeamsMap.get(parentSlug);
+        if (parentSummary) {
+          parentTeamId = parentSummary.id;
+        } else {
+          this.logger.warning(
+            `Parent team ${parentSlug} for ${slug} not found. Parent relationship will be skipped.`
+          );
+          this.recordFinding(
+            findings,
+            'warning',
+            `Parent team ${parentSlug} not found.`,
+            team.definition.name
+          );
+        }
+      }
+
+      const { members: targetMembers, manageMembers } = this.determineTargetMembers(
+        team.definition,
+        team.members
+      );
+
+      const diff: TeamDiff = calculateTeamDiff({
+        definition: team.definition,
+        slug,
+        targetMembers,
+        manageMembers,
+        existingTeam: existingState,
+        parentTeamId: parentTeamId ?? null,
+        targetParentSlug: parentSlug,
+      });
+
+      if (!hasTeamChanges(diff)) {
+        stats.skipped += 1;
+        this.recordFinding(findings, 'info', 'Team is already in desired state.', diff.team);
+        continue;
+      }
+
+      hasChanges = true;
+
+      try {
+        const outcome = await applyTeamDiffs(this.github, diff, {
+          dryRun,
+          logger: this.logger,
+          owner,
+        });
+
+        if (!dryRun) {
+          // Refresh cache for newly created or updated teams
+          const teamSummary = await this.github.getTeamBySlug(owner, outcome.slug);
+          if (teamSummary) {
+            existingTeamsMap.set(outcome.slug, teamSummary);
+          }
+        }
+
+        if (outcome.created) {
+          stats.created += 1;
+          this.recordFinding(findings, 'info', 'Team created.', diff.team);
+        }
+        const wasUpdated = !outcome.created && (outcome.updatedMetadata || outcome.updatedMembers);
+
+        if (outcome.updatedMetadata) {
+          this.recordFinding(findings, 'info', 'Team metadata updated.', diff.team);
+        }
+
+        if (outcome.updatedMembers) {
+          this.recordFinding(findings, 'info', 'Team memberships updated.', diff.team);
+        }
+
+        if (wasUpdated) {
+          stats.updated += 1;
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        hasErrors = true;
+        this.logger.error(`Failed to synchronize team ${slug}: ${message}`);
+        this.recordFinding(findings, 'error', 'Failed to synchronize team.', diff.team, {
+          error: message,
+        });
+      }
+    }
+
+    if (this.config.unmanaged_teams === 'warn') {
+      const configuredSlugs = new Set(
+        teamsToProcess.map((team) => slugifyTeamName(team.definition.name))
+      );
+      const unmanaged = [...existingTeamsMap.keys()].filter((slug) => !configuredSlugs.has(slug));
+      if (unmanaged.length > 0) {
+        this.recordFinding(
+          findings,
+          'warning',
+          'Teams exist in GitHub that are not managed by configuration.',
+          undefined,
+          { teams: unmanaged }
+        );
+      }
+    } else if (this.config.unmanaged_teams === 'remove') {
+      this.recordFinding(
+        findings,
+        'warning',
+        'Removal of unmanaged teams is not implemented yet.',
+        undefined
+      );
+    }
+
+    const summary = dryRun
+      ? `Preview: processed ${stats.processed} team(s) (created ${stats.created}, updated ${stats.updated}, skipped ${stats.skipped}).`
+      : `Processed ${stats.processed} team(s) (created ${stats.created}, updated ${stats.updated}, skipped ${stats.skipped}).`;
+
+    return {
+      hasChanges,
+      hasErrors,
+      findings,
+      summary,
+      stats,
+    };
   }
 }

--- a/src/teams/sync.ts
+++ b/src/teams/sync.ts
@@ -5,16 +5,177 @@ import type { TeamDiff } from './types';
 interface ApplyTeamDiffOptions {
   dryRun: boolean;
   logger: Logger;
+  owner: string;
+}
+
+export interface ApplyTeamDiffOutcome {
+  created: boolean;
+  updatedMetadata: boolean;
+  updatedMembers: boolean;
+  slug: string;
+}
+
+function describeChanges(diff: TeamDiff): string {
+  const changes: string[] = [];
+
+  if (!diff.exists) {
+    changes.push('create team');
+  }
+  if (diff.changes.description) {
+    changes.push('update description');
+  }
+  if (diff.changes.privacy) {
+    changes.push('update privacy');
+  }
+  if (diff.changes.parent) {
+    changes.push('update parent');
+  }
+  if (diff.changes.notification_setting) {
+    changes.push('update notifications');
+  }
+  if (diff.manageMembers) {
+    if (diff.changes.membersToAdd.length > 0) {
+      changes.push(`add ${diff.changes.membersToAdd.length} member(s)`);
+    }
+    if (diff.changes.membersToRemove.length > 0) {
+      changes.push(`remove ${diff.changes.membersToRemove.length} member(s)`);
+    }
+    if (diff.changes.membersToUpdateRole.length > 0) {
+      changes.push(`update ${diff.changes.membersToUpdateRole.length} role(s)`);
+    }
+  }
+
+  if (changes.length === 0) {
+    return 'no changes required';
+  }
+
+  return changes.join(', ');
 }
 
 export async function applyTeamDiffs(
-  _github: GitHubClient,
+  github: GitHubClient,
   diff: TeamDiff,
   options: ApplyTeamDiffOptions
-): Promise<void> {
-  const { logger, dryRun } = options;
-  const prefix = dryRun ? '[dry-run] ' : '';
-  logger.warning(
-    `${prefix}Team synchronization for ${diff.team} is not implemented; skipping apply step.`
-  );
+): Promise<ApplyTeamDiffOutcome> {
+  const { logger, dryRun, owner } = options;
+
+  const summary = describeChanges(diff);
+
+  if (dryRun) {
+    logger.info(`[dry-run] Team ${diff.slug}: ${summary}`);
+    return {
+      created: !diff.exists && summary !== 'no changes required',
+      updatedMetadata:
+        !!diff.exists &&
+        Boolean(
+          diff.changes.description ||
+            diff.changes.privacy ||
+            diff.changes.parent ||
+            diff.changes.notification_setting
+        ),
+      updatedMembers:
+        diff.manageMembers &&
+        (diff.changes.membersToAdd.length > 0 ||
+          diff.changes.membersToRemove.length > 0 ||
+          diff.changes.membersToUpdateRole.length > 0),
+      slug: diff.slug,
+    };
+  }
+
+  logger.info(`Synchronizing team ${diff.slug}: ${summary}`);
+
+  let currentSlug = diff.slug;
+  let created = false;
+  let updatedMetadata = false;
+  let updatedMembers = false;
+
+  // Create team if needed
+  if (!diff.exists) {
+    const createParams: {
+      name: string;
+      description?: string;
+      privacy?: 'secret' | 'closed';
+      parent_team_id?: number;
+      notification_setting?: 'notifications_enabled' | 'notifications_disabled';
+    } = {
+      name: diff.definition.name,
+    };
+
+    if (diff.definition.description !== undefined) {
+      createParams.description = diff.definition.description;
+    }
+    if (diff.definition.privacy !== undefined) {
+      createParams.privacy = diff.definition.privacy;
+    }
+    if (diff.definition.notification_setting !== undefined) {
+      createParams.notification_setting = diff.definition.notification_setting;
+    }
+    if (diff.targetParentId !== undefined && diff.targetParentId !== null) {
+      createParams.parent_team_id = diff.targetParentId;
+    }
+
+    const createdTeam = await github.createTeam(owner, createParams);
+    currentSlug = createdTeam.slug;
+    created = true;
+  } else if (
+    diff.changes.description ||
+    diff.changes.privacy ||
+    diff.changes.parent ||
+    diff.changes.notification_setting
+  ) {
+    const updateParams: {
+      name?: string;
+      description?: string | null;
+      privacy?: 'secret' | 'closed';
+      parent_team_id?: number | null;
+      notification_setting?: 'notifications_enabled' | 'notifications_disabled';
+    } = {};
+
+    updateParams.name = diff.definition.name;
+
+    if (diff.definition.description !== undefined) {
+      updateParams.description = diff.definition.description;
+    }
+    if (diff.definition.privacy !== undefined) {
+      updateParams.privacy = diff.definition.privacy;
+    }
+    if (diff.definition.notification_setting !== undefined) {
+      updateParams.notification_setting = diff.definition.notification_setting;
+    }
+    if (diff.targetParentId !== undefined) {
+      updateParams.parent_team_id = diff.targetParentId;
+    }
+
+    await github.updateTeam(owner, currentSlug, updateParams);
+    updatedMetadata = true;
+  }
+
+  if (diff.manageMembers) {
+    for (const member of diff.changes.membersToAdd) {
+      await github.addOrUpdateTeamMembership(
+        owner,
+        currentSlug,
+        member.username,
+        member.role ?? 'member'
+      );
+      updatedMembers = true;
+    }
+
+    for (const member of diff.changes.membersToUpdateRole) {
+      await github.addOrUpdateTeamMembership(owner, currentSlug, member.username, member.newRole);
+      updatedMembers = true;
+    }
+
+    for (const username of diff.changes.membersToRemove) {
+      await github.removeTeamMembership(owner, currentSlug, username);
+      updatedMembers = true;
+    }
+  }
+
+  return {
+    created,
+    updatedMetadata,
+    updatedMembers,
+    slug: currentSlug,
+  };
 }

--- a/src/teams/sync.ts
+++ b/src/teams/sync.ts
@@ -1,0 +1,20 @@
+import type { GitHubClient } from '../github';
+import type { Logger } from '../logging';
+import type { TeamDiff } from './types';
+
+interface ApplyTeamDiffOptions {
+  dryRun: boolean;
+  logger: Logger;
+}
+
+export async function applyTeamDiffs(
+  _github: GitHubClient,
+  diff: TeamDiff,
+  options: ApplyTeamDiffOptions
+): Promise<void> {
+  const { logger, dryRun } = options;
+  const prefix = dryRun ? '[dry-run] ' : '';
+  logger.warning(
+    `${prefix}Team synchronization for ${diff.team} is not implemented; skipping apply step.`
+  );
+}

--- a/src/teams/types.ts
+++ b/src/teams/types.ts
@@ -27,12 +27,18 @@ export interface GitHubTeamState {
   parent?: string | null;
   privacy?: 'closed' | 'secret';
   members: TeamMember[];
+  id?: number;
+  notification_setting?: 'notifications_enabled' | 'notifications_disabled' | null;
 }
 
 export interface TeamDiffChangeSet {
-  description?: { old?: string | null; new?: string };
+  description?: { old?: string | null; new?: string | null };
   privacy?: { old?: 'closed' | 'secret' | null; new?: 'closed' | 'secret' };
   parent?: { old?: string | null; new?: string | null };
+  notification_setting?: {
+    old?: 'notifications_enabled' | 'notifications_disabled' | null;
+    new?: 'notifications_enabled' | 'notifications_disabled' | null;
+  };
   membersToAdd: TeamMember[];
   membersToRemove: string[];
   membersToUpdateRole: { username: string; newRole: 'member' | 'maintainer' }[];
@@ -40,7 +46,13 @@ export interface TeamDiffChangeSet {
 
 export interface TeamDiff {
   team: string;
+  slug: string;
+  teamId?: number;
   exists: boolean;
+  definition: TeamDefinition;
+  targetMembers: TeamMember[];
+  manageMembers: boolean;
+  targetParentId?: number | null;
   changes: TeamDiffChangeSet;
 }
 
@@ -72,6 +84,7 @@ export interface SyncResult {
 export interface TeamSyncOptions {
   dryRun?: boolean;
   unmanagedTeams?: UnmanagedTeamsMode;
+  owner?: string;
 }
 
 export interface TeamSynchronizationContext {

--- a/src/teams/types.ts
+++ b/src/teams/types.ts
@@ -1,0 +1,80 @@
+import type {
+  DynamicTeamRule,
+  TeamDefinition,
+  TeamMember,
+  TeamsConfig,
+  UnmanagedTeamsMode,
+} from '../config/types';
+
+export type TeamSource = 'definition' | 'dynamic';
+
+export interface ResolvedTeam {
+  definition: TeamDefinition;
+  members: TeamMember[];
+  source: TeamSource;
+  rule?: DynamicTeamRule;
+}
+
+export interface ResolvedTeams {
+  staticTeams: ResolvedTeam[];
+  dynamicTeams: ResolvedTeam[];
+}
+
+export interface GitHubTeamState {
+  name: string;
+  slug: string;
+  description?: string | null;
+  parent?: string | null;
+  privacy?: 'closed' | 'secret';
+  members: TeamMember[];
+}
+
+export interface TeamDiffChangeSet {
+  description?: { old?: string | null; new?: string };
+  privacy?: { old?: 'closed' | 'secret' | null; new?: 'closed' | 'secret' };
+  parent?: { old?: string | null; new?: string | null };
+  membersToAdd: TeamMember[];
+  membersToRemove: string[];
+  membersToUpdateRole: { username: string; newRole: 'member' | 'maintainer' }[];
+}
+
+export interface TeamDiff {
+  team: string;
+  exists: boolean;
+  changes: TeamDiffChangeSet;
+}
+
+export type SyncFindingLevel = 'info' | 'warning' | 'error';
+
+export interface SyncFinding {
+  level: SyncFindingLevel;
+  message: string;
+  team?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface SyncStats {
+  processed: number;
+  created: number;
+  updated: number;
+  removed: number;
+  skipped: number;
+}
+
+export interface SyncResult {
+  hasChanges: boolean;
+  hasErrors: boolean;
+  findings: SyncFinding[];
+  summary: string;
+  stats: SyncStats;
+}
+
+export interface TeamSyncOptions {
+  dryRun?: boolean;
+  unmanagedTeams?: UnmanagedTeamsMode;
+}
+
+export interface TeamSynchronizationContext {
+  config: TeamsConfig;
+  owner?: string;
+}


### PR DESCRIPTION
## Summary
- scaffold team synchronization preview check and configuration support
- add teams module placeholders for dynamic rules and diff/apply helpers
- raise coverage around team schema and sync scaffolding

## Testing
- npm run test
- npm run test:coverage
- npm run lint
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a preview “team-sync” check and teams config schema to dry-run GitHub team synchronization. No changes are applied yet; this scaffolds the feature behind a safe preview.

- **New Features**
  - New check: team-sync (runs when teams config exists; compliant result with preview stats).
  - Teams config schema added: definitions, dynamic_rules, dry_run, unmanaged_teams.
  - Dynamic rule types: all_org_members, by_filter (with filter), composite (with compose).
  - Teams module scaffolding: manager, diff, dynamic resolution, apply (no-op), types.
  - Check registry updated to include team-sync.
  - Extensive tests for schema, manager, diff/dynamic/sync, and check wiring.

- **Migration**
  - Optional adoption: add a teams block to compliance config (can include definitions and/or dynamic_rules).
  - Enable the team-sync check via checks list if using an allowlist.
  - Run in dry-run to preview findings; fix still performs no changes while the feature is in preview.

<!-- End of auto-generated description by cubic. -->

